### PR TITLE
Fix invalid syntax

### DIFF
--- a/pyarabic/kalima.py
+++ b/pyarabic/kalima.py
@@ -121,7 +121,7 @@ class kalima:
 	def __iadd__(self, other):
 		self.letters+= other.letters;
 		self.marks  += other.marks;
-	def __add__(self.other):
+	def __add__(self, other):
 		return kalima(self.letters + other.letters, self.marks  + other.marks);
 
 	#####################################


### PR DESCRIPTION
Running `python{2,3} setup.py install` currently traces with invalid syntax:

```
byte-compiling build/bdist.linux-x86_64/egg/pyarabic/kalima.py to kalima.pyc
  File "build/bdist.linux-x86_64/egg/pyarabic/kalima.py", line 124
    def __add__(self.other):
                    ^
SyntaxError: invalid syntax
```
