### PR TITLE
Specify Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup (name='PyArabic', version='0.6.4',
           'Intended Audience :: Developers',
           'Operating System :: OS Independent',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
           'Topic :: Text Processing :: Linguistic',
           ],
     );


### PR DESCRIPTION
This is important to make it easy to detect programmatically or manually whether this package supports Python 3 or not.