### PR TITLE
fixed bug in read function - added encoding utf8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # to install type:
 # python setup.py install --root=/
 def readme():
-    with open('README.md') as f:
+    with open('README.md', encoding="utf8") as f:
         return f.read()
         
 setup (name='PyArabic', version='0.6.6',


### PR DESCRIPTION
Fixed the `read` function in `setup.py` as the encoding was not explicitly defined and that resulted in error while installing with `pip`.

The error was as follows during `pip install pyarabic`:
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 301: character maps to <undefined>`

Now the error is resolved.