### PR TITLE
Add digit normalization functionality

### DIFF
--- a/pyarabic/araby.py
+++ b/pyarabic/araby.py
@@ -94,8 +94,8 @@ SEVEN = u'\u0667'
 EIGHT = u'\u0668'
 NINE = u'\u0669'
 ZERO_W = u'\u0030'
-ONE_W  = u'\u0031'
-TWO_W  = u'\u0032'
+ONE_W = u'\u0031'
+TWO_W = u'\u0032'
 THREE_W = u'\u0033'
 FOUR_W = u'\u0034'
 FIVE_W = u'\u0035'
@@ -103,6 +103,16 @@ SIX_W = u'\u0036'
 SEVEN_W = u'\u0037'
 EIGHT_W = u'\u0038'
 NINE_W = u'\u0039'
+ZERO_P = u'\u06f0'
+ONE_P = u'\u06f1'
+TWO_P = u'\u06f2'
+THREE_P = u'\u06f3'
+FOUR_P = u'\u06f4'
+FIVE_P = u'\u06f5'
+SIX_P = u'\u06f6'
+SEVEN_P = u'\u06f7'
+EIGHT_P = u'\u06f8'
+NINE_P = u'\u06f9'
 PERCENT = u'\u066a'
 DECIMAL = u'\u066b'
 THOUSANDS = u'\u066c'
@@ -145,6 +155,9 @@ NUMBERS_EAST = (ZERO, ONE, TWO, THREE, FOUR, FIVE,\
                 SIX, SEVEN, EIGHT, NINE)
 NUMBERS_WEST = (ZERO_W, ONE_W, TWO_W, THREE_W, FOUR_W, FIVE_W,\
                 SIX_W, SEVEN_W, EIGHT_W, NINE_W)
+NUMBERS_PERS = (ZERO_P, ONE_P, TWO_P, THREE_P, FOUR_P, FIVE_P,\
+                SIX_P, SEVEN_P, EIGHT_P, NINE_P)
+
 
 TASHKEEL = (FATHATAN, DAMMATAN, KASRATAN, FATHA, DAMMA, KASRA, \
             SUKUN, SHADDA)
@@ -830,32 +843,7 @@ def strip_diacritics(text):
     for char in DIACRITICS:
         text = text.replace(char, '')
     return text
-    
-def normalize_digits(text, to_west=True):
-   """Normalize digits to western Arabic numerals if to_west is true,
-   eastern numerals (Hindu-Arabic) otherwise.
-
-    Example:
-        >>> text = u'٢٤٧٩٠٥٣٦٨'
-        >>> normalize_digits(text, to_west=True)
-        247905368
-        >>> text = u'247905368'
-        >>> normalize_digits(text, to_west=False)
-        ٢٤٧٩٠٥٣٦٨
-
-   @param text: arabic text.
-   @type text: unicode.
-   @param to_west: Whether to convert digits to western or eastern numerals.
-                   (default is True).
-   @type to_west: Bool
-   @return: returns a converted text.
-   @rtype: unicode.
-   """
-   trans_pair = zip(NUMBERS_EAST, NUMBERS_WEST) if to_west \
-                else zip(NUMBERS_WEST, NUMBERS_EAST)
-   trans_table = str.maketrans(dict(trans_pair))
-   return str(text).translate(trans_table)
-   
+ 
 def normalize_ligature(text):
     """Normalize Lam Alef ligatures into two letters (LAM and ALEF),
     and Tand return a result text.

--- a/tests/test_trans.py
+++ b/tests/test_trans.py
@@ -26,6 +26,24 @@ class ArabyTestCase(unittest.TestCase):
         self.assertEqual(trans.encode_tashkeel(word1, "decimal"), (letters, encoded_marks))
         self.assertEqual(trans.decode_tashkeel(letters, encoded_marks, "decimal"), word1)
 
+    def test_normalize_digits(self):
+        nd_text = u'۰۱۲۳۴۵۶۷۸۹ ٠١٢٣٤٥٦٧٨٩ 123456789 نص'
+        self.assertEqual(trans.normalize_digits(nd_text, source='all', out='east'), '٠١٢٣٤٥٦٧٨٩ ٠١٢٣٤٥٦٧٨٩ ١٢٣٤٥٦٧٨٩ نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='all', out='west'), '0123456789 0123456789 123456789 نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='all', out='persian'), '۰۱۲۳۴۵۶۷۸۹ ۰۱۲۳۴۵۶۷۸۹ ۱۲۳۴۵۶۷۸۹ نص') 
+   
+        self.assertEqual(trans.normalize_digits(nd_text, source='east', out='east'), '۰۱۲۳۴۵۶۷۸۹ ٠١٢٣٤٥٦٧٨٩ 123456789 نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='east', out='west'), '۰۱۲۳۴۵۶۷۸۹ 0123456789 123456789 نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='east', out='persian'), '۰۱۲۳۴۵۶۷۸۹ ۰۱۲۳۴۵۶۷۸۹ 123456789 نص') 
+
+        self.assertEqual(trans.normalize_digits(nd_text, source='west', out='east'), '۰۱۲۳۴۵۶۷۸۹ ٠١٢٣٤٥٦٧٨٩ ١٢٣٤٥٦٧٨٩ نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='west', out='west'), '۰۱۲۳۴۵۶۷۸۹ ٠١٢٣٤٥٦٧٨٩ 123456789 نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='west', out='persian'), '۰۱۲۳۴۵۶۷۸۹ ٠١٢٣٤٥٦٧٨٩ ۱۲۳۴۵۶۷۸۹ نص') 
+
+        self.assertEqual(trans.normalize_digits(nd_text, source='persian', out='east'), '٠١٢٣٤٥٦٧٨٩ ٠١٢٣٤٥٦٧٨٩ 123456789 نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='persian', out='west'), '0123456789 ٠١٢٣٤٥٦٧٨٩ 123456789 نص') 
+        self.assertEqual(trans.normalize_digits(nd_text, source='persian', out='persian'), '۰۱۲۳۴۵۶۷۸۹ ٠١٢٣٤٥٦٧٨٩ 123456789 نص') 
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
أضفت دالة لدعم التبديل بين الأرقام العربية الشرقية والغربية والفارسية/الأردو. 
هذه الخاصية تسهل عملية معالجة المدخلات وتوحيدها.
أضفتها في سكريبت `trans` لتدعم بايثون 3 و 2 
وأيضًا أضفت حالات تجريبية لكل الاحتمالات.