### PR TITLE
fix autocorrect and sentence_tokenize stopping after 32 matches

### DIFF
--- a/pyarabic/araby.py
+++ b/pyarabic/araby.py
@@ -1340,7 +1340,7 @@ def sentence_tokenize(text):
     @return: list of sentences.
     @rtype: list.
     """
-    text = re.sub(u"([.,:;،؟?\n])+([\n\t\r ])+",r"\1<SPLIT>", text, re.UNICODE)
+    text = re.sub(u"([.,:;،؟?\n])+([\n\t\r ])+",r"\1<SPLIT>", text, flags=re.UNICODE)
     sentences = re.split("<SPLIT>", text)
     return sentences 
 
@@ -1447,19 +1447,19 @@ def autocorrect(text):
     @rtype: unicode
     """
     ## HARAKAT
-    text = re.sub(u"(?<=[\s\d])([%s])+"%(TASHKEEL_STRING),"",text,  re.UNICODE)
-    text = re.sub(u"^([%s])+"%(TASHKEEL_STRING),"",text , re.UNICODE)
+    text = re.sub(u"(?<=[\s\d])([%s])+"%(TASHKEEL_STRING),"",text, flags=re.UNICODE)
+    text = re.sub(u"^([%s])+"%(TASHKEEL_STRING),"",text , flags=re.UNICODE)
     # tanwin on alef
-    text = re.sub(ALEF+FATHATAN, FATHATAN + ALEF,text , re.UNICODE)        
+    text = re.sub(ALEF+FATHATAN, FATHATAN + ALEF,text , flags=re.UNICODE)
 
     # SUKUN misplaced on alef /alef maksura and TEH merbuta
-    text = re.sub(u"(?<=[%s%s%s])([%s])+"%(ALEF, ALEF_MAKSURA, TEH_MARBUTA, SUKUN),"" , text, re.UNICODE)        
+    text = re.sub(u"(?<=[%s%s%s])([%s])+"%(ALEF, ALEF_MAKSURA, TEH_MARBUTA, SUKUN),"" , text, flags=re.UNICODE)
 
     # Hakara before Shadda
-    text = re.sub(u"([%s])+(?=[%s])"%(HARAKAT_STRING, SHADDA),"",text, re.UNICODE)
-    
+    text = re.sub(u"([%s])+(?=[%s])"%(HARAKAT_STRING, SHADDA),"",text, flags=re.UNICODE)
+
     # repeated harahat
-    text = re.sub(u"(?<=[%s])([%s])+"%(HARAKAT_STRING, HARAKAT_STRING),"",text,  re.UNICODE)
+    text = re.sub(u"(?<=[%s])([%s])+"%(HARAKAT_STRING, HARAKAT_STRING),"",text, flags=re.UNICODE)
     
     ## Letters
     return text 

--- a/tests/test_araby.py
+++ b/tests/test_araby.py
@@ -110,6 +110,11 @@ class ArabyTestCase(unittest.TestCase):
         text1 = u"حَرَكَة مُُضاعَفة َسابقة  قبل شَّدة سابقاً"
         text2 = u"حَرَكَة مُضاعَفة سابقة  قبل شّدة سابقًا"
         self.assertEqual(ar.autocorrect(text1), text2)
+        # more than 32 corrections in one call, used to stop after 32
+        # because re.UNICODE was passed as the count arg instead of flags
+        long1 = u" ".join([u"سابقاً"] * 40)
+        long2 = u" ".join([u"سابقًا"] * 40)
+        self.assertEqual(ar.autocorrect(long1), long2)
 
     def test_spellit(self):
         """Test  spellit"""
@@ -123,7 +128,10 @@ class ArabyTestCase(unittest.TestCase):
         """Test  sentence tokenize function ?"""
         text1 = u"العربية لغة جميلة. والبلاد بعيدة، والشوق زائد"
         sentences =['العربية لغة جميلة.', 'والبلاد بعيدة،', 'والشوق زائد']
-        self.assertEqual(ar.sentence_tokenize(text1), sentences)        
+        self.assertEqual(ar.sentence_tokenize(text1), sentences)
+        # more than 32 boundaries, the tail used to come back as one unsplit blob
+        long_text = u" ".join([u"جملة رقم."] * 40)
+        self.assertEqual(len(ar.sentence_tokenize(long_text)), 40)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
noticed autocorrect and sentence_tokenize quietly give up partway through longer text. both call re.sub with re.UNICODE as the 4th positional arg, but that slot is count, not flags. re.UNICODE happens to be 32 so each sub just stops after 32 replacements.

so autocorrect leaves any real-length text under-corrected past the 32nd match, and sentence_tokenize only inserts 32 split markers and hands back the whole tail as one unsplit sentence.

quick repro:

    import pyarabic.araby as ar
    text = " ".join(["سابقاً"] * 40)
    ar.autocorrect(text).count("ساب"+"قاً")   # 8 left uncorrected, should be 0
    len(ar.sentence_tokenize(" ".join(["جملة رقم."] * 40)))  # 33, should be 40

fix is just moving it to flags=re.UNICODE so the count goes back to unbounded. added a case to each of the existing tests with more than 32 matches, they fail before and pass after. full test_araby suite is green.